### PR TITLE
add ci: auto tagging about `Release`

### DIFF
--- a/.github/workflows/tag-commit-workflow.yml
+++ b/.github/workflows/tag-commit-workflow.yml
@@ -1,0 +1,31 @@
+name: Tag Commit Workflow
+
+on:
+  push:
+    branches:
+      - main
+      - ci/*
+
+jobs:
+  tag-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Git
+        run: |
+          git config --global user.name 'sonohoshi'
+          git config --global user.email 'dev.sonohoshi@gmail.com'
+
+      - name: Delete existing tag
+        run: |
+          if git rev-parse -q --verify "refs/tags/Release"; then
+            git tag -d Release
+            git push origin :refs/tags/Release
+          fi
+
+      - name: Tag the commit
+        run: |
+          git tag Release
+          git push origin Release

--- a/.github/workflows/tag-commit-workflow.yml
+++ b/.github/workflows/tag-commit-workflow.yml
@@ -17,6 +17,9 @@ jobs:
         run: |
           git config --global user.name '9c-liveAsset-ci'
           git config --global user.email 'dev.sonohoshi@gmail.com'
+          
+      - name: Fetch all tags
+        run: git fetch --tags
 
       - name: Delete existing tag
         run: |

--- a/.github/workflows/tag-commit-workflow.yml
+++ b/.github/workflows/tag-commit-workflow.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Setup Git
         run: |
-          git config --global user.name 'sonohoshi'
+          git config --global user.name '9c-liveAsset-ci'
           git config --global user.email 'dev.sonohoshi@gmail.com'
 
       - name: Delete existing tag


### PR DESCRIPTION
for using raw.githack.com

1. raw.githack.com을 이용하여 이미지 리소스에 임시 cdn을 붙이기로 했습니다.
2. 클라이언트에서는 rawcdn... url을 이용하여 [Release](https://github.com/planetarium/NineChronicles.LiveAssets/releases/tag/Release) 태그에 접근해서 값을 가져오게 바꿨습니다. ref: https://github.com/planetarium/NineChronicles/pull/3822
3. 그래서 main 브랜치에 push가 될때마다 헤드에 릴리즈 태그를 새로 달아주도록 하는 ci를 만들었습니다.